### PR TITLE
Enhance notification stream parsing in pyNetX v2.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ### Async-first NETCONF automation for Python
 
-**pyNetX** is a high-performance Python NETCONF client library with a native C++/pybind11 backend. It provides asyncio-friendly NETCONF RPCs, SSH-based NETCONF sessions, notification subscriptions, epoll-backed notification reactors, bounded notification queues, and process-wide notification health events.
+**pyNetX** is a high-performance, production level, Python NETCONF client library with a native C++/pybind11 backend. It provides asyncio-friendly NETCONF RPCs, SSH-based NETCONF sessions, notification subscriptions, epoll-backed notification reactors, bounded notification queues, and process-wide notification health events. It is battle-tested to manage **1,000+ live network devices** concurrently per instance.
 
 <br />
 
 [![PyPI](https://img.shields.io/pypi/v/pyNetX?label=PyPI&color=2563eb)](https://pypi.org/project/pyNetX/)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-3776ab)](#requirements)
-[![Version](https://img.shields.io/badge/Stable-v2.0.6-16a34a)](#v206--latest)
+[![Version](https://img.shields.io/badge/Stable-v2.0.7-16a34a)](#v207--latest)
 [![Protocol](https://img.shields.io/badge/Protocol-NETCONF-orange)](#why-pynetx)
 
 <br />
@@ -38,9 +38,10 @@ pyNetX is built for users who need more than a simple blocking NETCONF script. I
 | **epoll notification reactors** | Notification sockets are monitored by background reactors instead of one Python thread per device. |
 | **Bounded notification queues** | Per-client queues can be unbounded or bounded for controlled memory usage. |
 | **Health event stream** | Queue-full, drops, recovery, incomplete notifications, and timeout events are observable through `NotificationHealthEvent`. |
-| **Device labels** | v2.0.6 adds a user-provided `label` field to health events so devices can be identified beyond hostname/IP. |
-| **Event timestamps** | v2.0.6 adds UTC ISO-8601 millisecond timestamps to health events. |
-| **Expanded testing** | v2.0.6 includes deeper fake NETCONF integration tests and optional real Netopeer2/Sysrepo tests. |
+| **Malformed notification diagnostics** | v2.0.7 reports malformed notification frames, empty EOM frames, orphan fragments, and missing-EOM recovery through health events. |
+| **Device labels** | Health events include a user-provided `label` field so devices can be identified beyond hostname/IP. |
+| **Event timestamps** | Health events include UTC ISO-8601 millisecond timestamps. |
+| **Hardened notification parser** | v2.0.7 adds persistent stream parsing for coalesced, fragmented, and malformed notification payloads. |
 
 > Current protocol framing: pyNetX uses NETCONF 1.0 end-of-message framing (`]]>]]>`). NETCONF 1.1 chunked framing is not part of this release.
 
@@ -49,7 +50,7 @@ pyNetX is built for users who need more than a simple blocking NETCONF script. I
 ## Install
 
 ```bash
-pip install pyNetX==2.0.6
+pip install pyNetX==2.0.7
 ```
 
 Or install the latest available release:
@@ -177,11 +178,32 @@ asyncio.run(consume_notifications())
 
 pyNetX uses a separate notification SSH/NETCONF session for subscriptions, so normal RPCs can continue on the primary session while notifications are being received.
 
+### Notification stream parser behavior in v2.0.7
+
+NETCONF notifications arrive over SSH as a byte stream. One socket read can contain multiple notifications, part of one notification, one complete notification plus the start of the next one, or malformed device data. pyNetX v2.0.7 keeps a persistent receive buffer for each notification subscription and parses that stream instead of assuming one read equals one notification.
+
+Handled cases include:
+
+| Device stream case | pyNetX behavior | Health event |
+|---|---|---|
+| One complete notification ending in `]]>]]>` | Queues the notification with the EOM marker. | None |
+| Multiple complete notifications in one read | Splits and queues each notification separately. | None |
+| Complete notification followed by a partial next notification | Queues the complete notification and keeps the partial bytes until more data or a guard fires. | None immediately |
+| Partial notification completed by a later read | Combines the saved partial bytes with the later bytes and queues one complete notification. | None |
+| New `<notification>` starts before the previous notification completed | Queues the abandoned previous fragment for inspection and continues from the new notification. | `incomplete_notification` |
+| EOM-delimited data is not valid notification XML | Queues the malformed frame for inspection. | `malformed_notification` |
+| Empty EOM-only frame | Drops the empty frame. | `malformed_notification` |
+| Orphan bytes before a notification start tag | Drops the orphan prefix and continues parsing the notification. | `malformed_notification` |
+| Complete notification XML followed by another notification but missing EOM between them | Recovers and queues the first notification without adding a synthetic EOM. | `malformed_notification` |
+| Partial data never receives EOM before timeout/size guard | Queues the partial bytes without EOM. | `incomplete_notification` |
+
+Valid complete notifications remain backward-compatible: EOM-delimited notifications are returned with `]]>]]>` included. Partial and recovered missing-EOM fragments are returned exactly as received, without adding a synthetic EOM.
+
 ---
 
 ## Quick start: notification health events
 
-pyNetX v2.0.6 health events include both `timestamp` and `label`:
+pyNetX health events include both `timestamp` and `label`:
 
 ```python
 import asyncio
@@ -226,6 +248,7 @@ Common event types:
 | `notification_queue_full` | A bounded per-client notification queue became full and a notification was dropped. |
 | `notification_drops_summary` | More notifications were dropped while the queue remained full. Frequency is controlled by `notif_drop_event_threshold`. |
 | `notification_queue_recovered` | A previously full queue has free capacity again. |
+| `malformed_notification` | Malformed notification stream data was detected, such as empty EOM frames, invalid XML, orphan bytes before a notification, or recovered missing-EOM frames. |
 | `incomplete_notification` | Partial notification data was received without the NETCONF `]]>]]>` EOM marker and a guard fired. |
 | `timeout` | No health event was available before the requested timeout. This event has `valid == False` and `label == "None"`. |
 
@@ -436,7 +459,20 @@ See `docs/source/testing.rst` or the generated documentation for the full test c
 
 ---
 
-## v2.0.6 — latest
+## v2.0.7 — latest
+
+v2.0.7 focuses on hardened notification stream parsing for devices that coalesce, fragment, or corrupt notification payloads.
+
+Highlights:
+
+- Added a persistent per-subscription notification receive buffer.
+- Split multiple `]]>]]>`-delimited notifications received in one SSH read into separate queue entries.
+- Preserved trailing partial notification bytes across reactor callbacks.
+- Detected and reported abandoned partial notifications when a new `<notification>` starts before the previous one completed.
+- Added `malformed_notification` health events for malformed EOM-delimited frames, empty EOM frames, orphan bytes before a notification, and recovered missing-EOM frames.
+- Reset notification parser state during subscription cleanup, dead-session cleanup, and queue clearing.
+
+## v2.0.6
 
 v2.0.6 focuses on better device identification, event timing, and stronger release testing.
 

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -2,7 +2,7 @@ API reference
 =============
 
 This page documents the public Python API exposed by the ``pyNetX`` package in
-v2.0.6.
+v2.0.7.
 
 Constructor
 -----------
@@ -48,7 +48,7 @@ Parameters
      - SSH password.
    * - ``key_path``
      - ``""``
-     - Reserved for key-based authentication. Password authentication is the implemented path in v2.0.6.
+     - Reserved for key-based authentication. Password authentication is the implemented path in v2.0.7.
    * - ``connect_timeout``
      - ``60``
      - Overall connection/session setup timeout.
@@ -204,6 +204,24 @@ Returns whether the notification subscription/session is active.
 
 Deletes/closes the notification subscription session. This is useful in cleanup
 blocks and is not deprecated.
+
+
+Notification parser diagnostics
+-------------------------------
+
+The notification receiver in v2.0.7 parses a persistent stream buffer. It can
+split multiple EOM-delimited notifications from one SSH read, retain partial
+trailing bytes across reads, recover a complete notification when the device
+omits EOM before starting the next notification, and emit health events for bad
+stream data.
+
+Diagnostic health event types include:
+
+- ``malformed_notification`` for empty EOM frames, invalid EOM-delimited XML,
+  orphan bytes before a notification start tag, and recovered missing-EOM frames.
+- ``incomplete_notification`` when a partial notification times out, exceeds the
+  configured partial-size guard, or is abandoned because a new
+  ``<notification>`` starts before the previous notification completed.
 
 Notification health event APIs
 ------------------------------

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -38,11 +38,12 @@ Notification flow
    NETCONF device
      -> notification SSH/NETCONF session
      -> epoll notification reactor
+     -> persistent notification stream parser
      -> per-client notification queue
      -> next_notification() / next_notification_async()
      -> NotificationHealthEvent stream when pressure or errors occur
 
-Normal RPC traffic and notification traffic use separate SSH/NETCONF sessions.
+Normal RPC traffic and notification traffic use separate SSH/NETCONF sessions. The notification path keeps a per-client receive buffer so coalesced frames, fragmented frames, and malformed fragments can be classified before data is exposed through the queue.
 
 Global components
 -----------------
@@ -75,6 +76,22 @@ Notification reactors use epoll to monitor notification sockets.
 
 Configure this during process startup before creating subscriptions.
 
+
+Notification stream parser
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+NETCONF notifications arrive over SSH as bytes, not as one notification per
+read. pyNetX v2.0.7 stores unread or incomplete notification bytes in a
+persistent per-client receive buffer. The parser repeatedly extracts complete
+``]]>]]>``-delimited frames, keeps trailing partial bytes for later reads, and
+raises health events when malformed stream data is detected.
+
+The parser handles multiple complete notifications in one read, complete frames
+followed by partial trailing data, partial frames completed by later reads,
+abandoned partial frames when a new ``<notification>`` starts too early, empty
+EOM frames, orphan bytes before a notification start tag, and complete
+notifications recovered without an EOM before the next notification.
+
 Event bus
 ~~~~~~~~~
 
@@ -85,7 +102,7 @@ consumers read events with ``next_notification_event()`` or
 NETCONF framing
 ---------------
 
-pyNetX v2.0.6 uses NETCONF 1.0 EOM framing with ``]]>]]>``.
+pyNetX v2.0.7 uses NETCONF 1.0 EOM framing with ``]]>]]>``.
 
 Custom RPC callers should provide only the XML RPC payload. pyNetX appends the
 EOM marker internally.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,8 +8,8 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "pyNetX"
 copyright = "2026, Sambhu Nampoothiri G"
 author = "Sambhu Nampoothiri G"
-release = "2.0.6"
-version = "2.0.6"
+release = "2.0.7"
+version = "2.0.7"
 
 extensions = []
 
@@ -22,4 +22,4 @@ exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "alabaster"
 html_static_path = ["_static"]
-html_title = "pyNetX 2.0.6 documentation"
+html_title = "pyNetX 2.0.7 documentation"

--- a/docs/source/health_events.rst
+++ b/docs/source/health_events.rst
@@ -2,8 +2,7 @@ Notification health events
 ==========================
 
 The notification health event stream is process-wide. It reports notification
-queue pressure, dropped notifications, recovery, incomplete notifications, and
-consumer wait timeouts.
+queue pressure, dropped notifications, recovery, incomplete notifications, malformed notification stream data, and consumer wait timeouts.
 
 Reading health events
 ---------------------
@@ -67,7 +66,7 @@ Event schema
      - ``False`` for timeout events, ``True`` for real health events.
    * - ``type``
      - ``str``
-     - Event type such as ``notification_queue_full``.
+     - Event type such as ``notification_queue_full`` or ``malformed_notification``.
    * - ``timestamp``
      - ``str``
      - UTC ISO-8601 timestamp with millisecond precision, for example ``2026-06-25T05:35:15.123Z``.
@@ -109,7 +108,7 @@ Event schema
      - Number of incomplete notifications observed.
    * - ``partial_bytes``
      - ``int``
-     - Partial notification bytes involved in an incomplete-notification event.
+     - Partial or malformed notification bytes involved in a diagnostic event.
    * - ``health_events_dropped``
      - ``int``
      - Number of health events dropped by the bounded global event bus.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-pyNetX 2.0.6 documentation
+pyNetX 2.0.7 documentation
 =============================
 
 pyNetX is an async-first Python NETCONF client with a C++/pybind11 backend,
@@ -6,10 +6,10 @@ libssh2 SSH transport, asyncio-friendly APIs, epoll-backed notification
 reactors, bounded notification queues, and structured notification health
 events.
 
-Version 2.0.6 adds device labels and UTC timestamps to notification health
-events, expands non-deprecated API test coverage, and documents the release
-validation workflow for repaired manylinux wheels and optional Netopeer2/Sysrepo
-integration testing.
+Version 2.0.7 hardens notification stream parsing for devices that coalesce,
+fragment, or corrupt notification payloads. It preserves the v2.0.6 health-event
+``label`` and ``timestamp`` fields and adds clearer diagnostics for malformed
+notification stream data.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,7 +6,7 @@ Install from PyPI
 
 .. code-block:: bash
 
-   pip install pyNetX==2.0.6
+   pip install pyNetX==2.0.7
 
 Or install the latest available release:
 
@@ -17,7 +17,7 @@ Or install the latest available release:
 Python support
 --------------
 
-pyNetX v2.0.6 requires Python 3.11 or newer.
+pyNetX v2.0.7 requires Python 3.11 or newer.
 
 The release workflow builds manylinux wheels for Python 3.11, 3.12, 3.13, and
 3.14.

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -18,7 +18,7 @@ What pyNetX provides
 - epoll-backed notification reactor threads.
 - Per-client notification queues.
 - A process-wide notification health event stream.
-- Device labels and UTC timestamps in health events starting in v2.0.6.
+- Device labels, UTC timestamps, and notification stream health diagnostics.
 
 Current protocol behavior
 -------------------------
@@ -27,7 +27,7 @@ pyNetX currently uses NETCONF 1.0 end-of-message framing with the ``]]>]]>``
 marker. Do not append this marker in custom RPC payloads; pyNetX appends it
 internally.
 
-NETCONF 1.1 chunked framing is not part of v2.0.6.
+NETCONF 1.1 chunked framing is not part of v2.0.7.
 
 Async-first direction
 ---------------------
@@ -46,6 +46,23 @@ The following helper APIs are not deprecated:
 - ``delete_subscription()``
 - notification health event APIs
 - global thread-pool and reactor configuration APIs
+
+
+New in v2.0.7
+-------------
+
+- Notification reads are parsed as a continuous byte stream instead of assuming
+  one SSH read equals one notification.
+- Multiple EOM-delimited notifications received in one read are split into
+  separate queue entries.
+- Trailing partial notification bytes are preserved across reactor callbacks and
+  combined with later bytes when the notification completes.
+- If a new ``<notification>`` starts before the previous notification completed,
+  pyNetX queues the abandoned previous fragment and emits an
+  ``incomplete_notification`` health event.
+- Malformed stream data such as empty EOM frames, invalid EOM-delimited XML,
+  orphan bytes before a notification, and recovered missing-EOM frames emits
+  ``malformed_notification`` health events.
 
 New in v2.0.6
 -------------

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -95,3 +95,16 @@ value is a UTC ISO-8601 string with millisecond precision and ``Z`` suffix.
 
 Timeout events are not associated with a specific client and use
 ``label == "None"``.
+
+Notification behavior in v2.0.7
+--------------------------------
+
+Applications that consume notifications should be aware of the stricter stream
+parser diagnostics added in v2.0.7. Valid EOM-delimited notifications are still
+returned with ``]]>]]>`` included. When a device sends malformed stream data,
+pyNetX may also queue diagnostic payloads exactly as received and emit either
+``malformed_notification`` or ``incomplete_notification`` health events.
+
+Consumers that previously assumed every queued item was a valid full notification
+should monitor the health event stream and treat queued payloads associated with
+parser diagnostics as device evidence for logging or investigation.

--- a/docs/source/notifications.rst
+++ b/docs/source/notifications.rst
@@ -83,6 +83,58 @@ Example bounded queue:
        label="leaf-01",
    )
 
+
+Notification stream parser behavior
+-----------------------------------
+
+pyNetX v2.0.7 treats the notification SSH channel as a byte stream. A single
+reactor callback may receive multiple complete notifications, one complete
+notification plus part of the next one, only part of a notification, or malformed
+device data. The client keeps a persistent receive buffer for the active
+subscription and parses from that buffer.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Device stream case
+     - Behavior
+     - Health event
+   * - One complete notification ending in ``]]>]]>``
+     - Queued with the EOM marker.
+     - None
+   * - Multiple complete notifications in one read
+     - Split and queued as separate notifications.
+     - None
+   * - Complete notification followed by partial next notification
+     - Complete notification is queued; trailing partial bytes stay in the receive buffer.
+     - None immediately
+   * - Partial notification completed by a later read
+     - Saved partial bytes are combined with later bytes and queued as one complete notification.
+     - None
+   * - New ``<notification>`` starts before the previous one completed
+     - Previous fragment is queued as an abandoned partial and parsing continues from the new start tag.
+     - ``incomplete_notification``
+   * - EOM-delimited data is not valid notification XML
+     - Malformed frame is queued for inspection.
+     - ``malformed_notification``
+   * - Empty EOM-only frame
+     - Empty frame is dropped.
+     - ``malformed_notification``
+   * - Orphan bytes before a notification start tag
+     - Orphan prefix is dropped and parsing continues.
+     - ``malformed_notification``
+   * - Complete notification XML is followed by another notification without an EOM between them
+     - First notification is recovered and queued without adding a synthetic EOM.
+     - ``malformed_notification``
+   * - Partial bytes never receive EOM before a guard fires
+     - Partial bytes are queued without EOM.
+     - ``incomplete_notification``
+
+For backward compatibility, valid EOM-delimited notifications returned by
+``next_notification()`` and ``next_notification_async()`` still include the
+``]]>]]>`` marker. Partial and recovered missing-EOM fragments are returned as
+received, without adding a synthetic marker.
+
 Incomplete notification guards
 ------------------------------
 
@@ -94,4 +146,4 @@ the NETCONF ``]]>]]>`` end marker. pyNetX has two guards:
 
 At least one guard must remain enabled. Do not set both to ``-1``.
 
-When a guard fires, pyNetX emits an ``incomplete_notification`` health event.
+When a guard fires, pyNetX emits an ``incomplete_notification`` health event and queues the partial bytes for inspection.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,8 +1,53 @@
 Release notes
 =============
 
-v2.0.6 — latest
+v2.0.7 — latest
 ---------------
+
+Focus: hardened notification stream parsing for devices that coalesce,
+fragment, or corrupt NETCONF notification payloads.
+
+Added
+~~~~~
+
+- Added a persistent per-subscription notification receive buffer.
+- Added stream parsing that can split multiple ``]]>]]>``-delimited
+  notifications received in one SSH read into separate queue entries.
+- Added preservation of trailing partial notification bytes across notification
+  reactor callbacks.
+- Added detection for abandoned partial notifications when a new
+  ``<notification>`` start tag appears before the previous notification
+  completed.
+- Added ``malformed_notification`` health events for malformed notification
+  stream data.
+
+Changed
+~~~~~~~
+
+- Notification delivery no longer treats one libssh2 read as one notification.
+- Valid complete EOM-delimited notifications continue to be queued with the EOM
+  marker included for backward compatibility.
+- Partial notifications and recovered missing-EOM fragments are queued exactly as
+  received, without adding a synthetic EOM marker.
+- Notification parser state is cleared during subscription reset, dead-session
+  cleanup, and notification queue clearing.
+
+Handled bad-device cases
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Multiple complete notifications combined in one SSH read.
+- One complete notification followed by a partial next notification.
+- Partial notification bytes completed by a later read.
+- A new notification start arriving before the previous notification completed.
+- Empty EOM-only frames.
+- EOM-delimited data that is not valid notification XML.
+- Orphan bytes before a notification start tag.
+- Complete notification XML followed by another notification without EOM between
+  them.
+- Partial data that never receives EOM before the timeout or size guard fires.
+
+v2.0.6
+------
 
 Focus: device-identifiable health events, event timing, and expanded release
 testing.

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -85,7 +85,7 @@ closed local TCP port.
 Uses a local Paramiko-based fake NETCONF-over-SSH server. It tests async
 connect/RPC/disconnect, built-in RPC builders, subscription flow, notifications,
 queue-full events, drop summaries, queue recovery, labels, timestamps, default
-label behavior, and incomplete-notification events.
+label behavior, and incomplete-notification events, malformed notification events, and coalesced/fragmented notification stream parsing.
 
 ``test_client_lifecycle_and_concurrency.py``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -98,8 +98,8 @@ two independent clients, and delete-subscription/resubscribe behavior.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Checks queue peek non-destructiveness, FIFO ordering, ``peek_notifications(-1)``,
-zero-sized bounded queues, high-watermark behavior, and incomplete notification
-size guards.
+zero-sized bounded queues, high-watermark behavior, incomplete notification
+size guards, and bad-device notification stream cases.
 
 ``test_rpc_payloads_and_framing.py``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -156,7 +156,7 @@ Create a clean Python 3.11 environment and install the matching wheel:
    python -m pip install -U pip
    python -m pip install pytest pytest-asyncio paramiko
    python -m pip install -r /home/sambhu/Documents/pyNetX/netconf_pybind/test/requirements.txt
-   python -m pip install /home/sambhu/Documents/pyNetX/netconf_pybind/wheelhouse/pynetx-2.0.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+   python -m pip install /home/sambhu/Documents/pyNetX/netconf_pybind/wheelhouse/pynetx-2.0.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
 
 Verify from outside the repository root:
 

--- a/include/netconf_client.hpp
+++ b/include/netconf_client.hpp
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <unistd.h>
 #include <sys/epoll.h>
+#include <chrono>
 
 // RAII Wrapper for an epoll file descriptor.
 class EpollRAII {
@@ -352,6 +353,18 @@ private:
     std::mutex session_mutex_;
     std::mutex ssh_mutex_;
     std::mutex dns_mutex_;
+
+    // This is a Persistent NETCONF notification receive buffer.
+    // One SSH read can contain:
+    //   - multiple complete EOM-delimited notifications
+    //   - one complete notification plus trailing partial bytes
+    //   - only malformed/orphan bytes
+    //   - notification XML without EOM
+    //
+    // Protected by _notif_queue_mtx.
+    std::string _notif_rx_buffer;
+    bool _notif_rx_partial_timer_active = false;
+    std::chrono::steady_clock::time_point _notif_rx_partial_started_at{};
 
     // Protects notif_session_, notif_channel_, notif_socket_,
     // notif_is_connected_, and notif_is_blocking_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyNetX"
-version = "2.0.6"
+version = "2.0.7"
 description = "NETCONF client with truly async capabilities"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="pyNetX",
-    version="2.0.6",
+    version="2.0.7",
     description="NETCONF client with truly async capabilities",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/netconf_client_blocking.cpp
+++ b/src/netconf_client_blocking.cpp
@@ -74,6 +74,8 @@ void NetconfClient::clear_notification_queue() {
         {
             std::lock_guard<std::mutex> lk(_notif_queue_mtx);
             _notif_queue.clear();
+            _notif_rx_buffer.clear();
+            _notif_rx_partial_timer_active = false;
             _notif_queue_full_state = false;
             _notif_queue_high_watermark = 0;
         }

--- a/src/netconf_client_non_blocking.cpp
+++ b/src/netconf_client_non_blocking.cpp
@@ -18,6 +18,240 @@
 #include <poll.h>
 #include <unistd.h>
 #include <errno.h>
+#include <algorithm>
+#include <cctype>
+
+namespace {
+    constexpr const char* NETCONF_NOTIFICATION_EOM = "]]>]]>";
+    constexpr std::size_t NETCONF_NOTIFICATION_EOM_LEN = 6;
+    constexpr int NOTIFICATION_POLL_SLICE_MS = 1000;
+
+    std::string trim_copy(const std::string& input) {
+        auto begin = std::find_if_not(input.begin(), input.end(), [](unsigned char c) {
+            return std::isspace(c) != 0;
+        });
+        auto end = std::find_if_not(input.rbegin(), input.rend(), [](unsigned char c) {
+            return std::isspace(c) != 0;
+        }).base();
+
+        if (begin >= end) {
+            return std::string{};
+        }
+
+        return std::string(begin, end);
+    }
+
+    std::string xml_local_name(const char* name) {
+        if (!name) {
+            return std::string{};
+        }
+
+        std::string value(name);
+        const std::size_t colon = value.rfind(':');
+        if (colon != std::string::npos) {
+            return value.substr(colon + 1);
+        }
+        return value;
+    }
+
+    bool is_valid_notification_document(const std::string& frame_without_eom) {
+        const std::string payload = trim_copy(frame_without_eom);
+        if (payload.empty()) {
+            return false;
+        }
+
+        tinyxml2::XMLDocument doc;
+        const tinyxml2::XMLError parse_status = doc.Parse(payload.c_str(), payload.size());
+        if (parse_status != tinyxml2::XML_SUCCESS) {
+            return false;
+        }
+
+        tinyxml2::XMLElement* root = doc.RootElement();
+        if (!root) {
+            return false;
+        }
+
+        return xml_local_name(root->Name()) == "notification";
+    }
+
+    std::size_t find_notification_start_tag(
+        const std::string& data,
+        std::size_t from = 0
+    ) {
+        std::size_t pos = from;
+
+        while (true) {
+            pos = data.find('<', pos);
+            if (pos == std::string::npos) {
+                return std::string::npos;
+            }
+
+            if (pos + 1 >= data.size()) {
+                return std::string::npos;
+            }
+
+            const char next = data[pos + 1];
+            if (next == '/' || next == '!' || next == '?') {
+                ++pos;
+                continue;
+            }
+
+            std::size_t name_begin = pos + 1;
+            std::size_t name_end = name_begin;
+            while (name_end < data.size()) {
+                unsigned char c = static_cast<unsigned char>(data[name_end]);
+                if (std::isspace(c) || data[name_end] == '>' || data[name_end] == '/') {
+                    break;
+                }
+                ++name_end;
+            }
+
+            if (name_end == name_begin) {
+                ++pos;
+                continue;
+            }
+
+            std::string qname = data.substr(name_begin, name_end - name_begin);
+            const std::size_t colon = qname.rfind(':');
+            const std::string local =
+                colon == std::string::npos ? qname : qname.substr(colon + 1);
+
+            if (local == "notification") {
+                return pos;
+            }
+
+            pos = name_end;
+        }
+    }
+
+    bool benign_notification_prefix(const std::string& prefix) {
+        const std::string trimmed = trim_copy(prefix);
+        if (trimmed.empty()) {
+            return true;
+        }
+
+        if (trimmed.rfind("<?xml", 0) == 0) {
+            const std::size_t end_decl = trimmed.find("?>");
+            if (end_decl != std::string::npos) {
+                return trim_copy(trimmed.substr(end_decl + 2)).empty();
+            }
+        }
+
+        return false;
+    }
+
+    bool notification_end_after_start(
+        const std::string& data,
+        std::size_t start,
+        std::size_t& end_after
+    ) {
+        if (start == std::string::npos || start + 1 >= data.size()) {
+            return false;
+        }
+
+        std::size_t name_begin = start + 1;
+        std::size_t name_end = name_begin;
+        while (name_end < data.size()) {
+            unsigned char c = static_cast<unsigned char>(data[name_end]);
+            if (std::isspace(c) || data[name_end] == '>' || data[name_end] == '/') {
+                break;
+            }
+            ++name_end;
+        }
+
+        if (name_end == name_begin) {
+            return false;
+        }
+
+        const std::string qname = data.substr(name_begin, name_end - name_begin);
+        const std::string close_tag = "</" + qname + ">";
+        const std::size_t close_pos = data.find(close_tag, name_end);
+        if (close_pos == std::string::npos) {
+            return false;
+        }
+
+        end_after = close_pos + close_tag.size();
+        return true;
+    }
+
+    std::string read_available_notification_bytes(
+        LIBSSH2_CHANNEL* chan,
+        LIBSSH2_SESSION* sess
+    ) {
+        if (!chan || !sess) {
+            throw NetconfException("Notification channel/session is not active");
+        }
+
+        std::string bytes;
+        char buffer[4096];
+
+        while (true) {
+            int nbytes = libssh2_channel_read_nonblocking(
+                chan,
+                buffer,
+                sizeof(buffer),
+                0
+            );
+
+            if (nbytes > 0) {
+                bytes.append(buffer, nbytes);
+                continue;
+            }
+
+            if (nbytes == 0 || nbytes == LIBSSH2_ERROR_EAGAIN) {
+                break;
+            }
+
+            char* err_msg = nullptr;
+            libssh2_session_last_error(sess, &err_msg, nullptr, 0);
+            throw NetconfException(
+                "Error reading from notification channel: " +
+                std::string(err_msg ? err_msg : "Unknown error")
+            );
+        }
+
+        return bytes;
+    }
+
+    int poll_notification_fd(int fd, int timeout_ms) {
+        if (fd < 0) {
+            throw NetconfException("Invalid notification socket while waiting for EOM");
+        }
+
+        while (true) {
+            struct pollfd pfd{};
+            pfd.fd = fd;
+            pfd.events = POLLIN | POLLPRI;
+
+            int ret = poll(&pfd, 1, timeout_ms);
+            if (ret < 0) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                throw NetconfException(
+                    "Poll error while waiting for notification EOM: " +
+                    std::string(strerror(errno))
+                );
+            }
+
+            if (ret == 0) {
+                return 0;
+            }
+
+            if (pfd.revents & POLLNVAL) {
+                throw NetconfException("Invalid notification socket while waiting for EOM");
+            }
+            if (pfd.revents & (POLLERR | POLLHUP)) {
+                throw NetconfException("Notification socket closed while waiting for EOM");
+            }
+            if (pfd.revents & (POLLIN | POLLPRI)) {
+                return 1;
+            }
+
+            return 0;
+        }
+    }
+}
 
 bool NetconfClient::connect_non_blocking() {
     if (is_connected_) {
@@ -529,8 +763,9 @@ void NetconfClient::mark_notification_dead() noexcept {
         {
             std::lock_guard<std::mutex> lk(_notif_queue_mtx);
             _notif_queue.clear();
+            _notif_rx_buffer.clear();
+            _notif_rx_partial_timer_active = false;
         }
-
         _notif_queue_cv.notify_all();
     } catch (...) {
         // Never throw from cleanup called by reactor thread.
@@ -539,53 +774,46 @@ void NetconfClient::mark_notification_dead() noexcept {
 
 void NetconfClient::on_notification_ready(int fd) {
     try {
-        std::string xml;
-
-        {
-            std::lock_guard<std::mutex> guard(notif_mutex_);
-
-            if (!notif_channel_ || !notif_session_) {
-                throw NetconfException("Notification channel/session is not active");
-            }
-
-            if (notif_socket_.get() != fd) {
-                throw NetconfException("Notification FD does not match active subscription socket");
-            }
-
-            xml = read_until_eom_non_blocking(
-                notif_channel_.get(),
-                notif_session_.get(),
-                fd,
-                -1,  // actual notification read: wait until EOM or incomplete guard
-                notif_incomplete_max_kb_,
-                notif_incomplete_timeout_
-            );
-        }
-
-        if (xml.empty()) {
-            return;
-        }
-
-        const bool is_incomplete_notification =
-            (xml.find("]]>]]>") == std::string::npos);
-
         std::vector<NotificationHealthEvent> events_to_emit;
-        bool queued_notification = false;
+        std::size_t queued_notifications = 0;
 
-        {
-            std::lock_guard<std::mutex> lk(_notif_queue_mtx);
+        auto flush_events_and_notifications = [&]() {
+            for (auto& event : events_to_emit) {
+                NotificationEventBus::instance().emit(std::move(event));
+            }
+            events_to_emit.clear();
 
-            if (is_incomplete_notification) {
+            if (queued_notifications > 0) {
+                _notif_queue_cv.notify_all();
+                queued_notifications = 0;
+            }
+        };
+
+        auto add_diagnostic_event_locked = [&](
+            const std::string& type,
+            const std::string& message,
+            std::int64_t partial_bytes,
+            bool increment_incomplete_count
+        ) {
+            if (increment_incomplete_count) {
                 ++_notif_incomplete_count;
-                events_to_emit.push_back(
-                    make_notification_health_event_locked(
-                        "incomplete_notification",
-                        "Received notification bytes without NETCONF EOM; queued partial notification",
-                        fd,
-                        0,
-                        static_cast<std::int64_t>(xml.size())
-                    )
-                );
+            }
+
+            events_to_emit.push_back(
+                make_notification_health_event_locked(
+                    type,
+                    message,
+                    fd,
+                    0,
+                    partial_bytes
+                )
+            );
+        };
+
+        auto enqueue_or_drop_locked = [&](std::string notification,
+                                          std::int64_t diagnostic_bytes) {
+            if (notification.empty()) {
+                return;
             }
 
             if (_notif_queue_max_size_ >= 0 &&
@@ -595,10 +823,6 @@ void NetconfClient::on_notification_ready(int fd) {
                 const std::uint64_t dropped_delta =
                     _notif_dropped_queue_full_count - _notif_last_drop_event_count;
 
-                // Emit immediately when the queue first becomes full, then emit
-                // summarized updates every notif_drop_event_threshold additional
-                // drops. Default is 1, which emits one health event per dropped
-                // notification while the queue remains full.
                 const bool first_queue_full_event = !_notif_queue_full_state;
 
                 if (first_queue_full_event ||
@@ -614,9 +838,7 @@ void NetconfClient::on_notification_ready(int fd) {
                             "Notification queue is full; dropping notifications",
                             fd,
                             static_cast<std::int64_t>(dropped_delta),
-                            is_incomplete_notification
-                                ? static_cast<std::int64_t>(xml.size())
-                                : 0
+                            diagnostic_bytes
                         )
                     );
 
@@ -629,26 +851,336 @@ void NetconfClient::on_notification_ready(int fd) {
                         << std::endl;
                 }
 
-                // Do not enqueue or notify consumers. The health event stream
-                // carries the drop information to Python.
-            } else {
-                _notif_queue.push_back(std::move(xml));
-                queued_notification = true;
+                return;
+            }
 
-                ++_notif_enqueued_count;
+            _notif_queue.push_back(std::move(notification));
+            ++queued_notifications;
+            ++_notif_enqueued_count;
 
-                if (_notif_queue.size() > _notif_queue_high_watermark) {
-                    _notif_queue_high_watermark = _notif_queue.size();
+            if (_notif_queue.size() > _notif_queue_high_watermark) {
+                _notif_queue_high_watermark = _notif_queue.size();
+            }
+        };
+
+        auto process_eom_frame_locked = [&](const std::string& frame_without_eom) {
+            const std::string trimmed = trim_copy(frame_without_eom);
+            const std::int64_t frame_bytes =
+                static_cast<std::int64_t>(frame_without_eom.size());
+
+            if (trimmed.empty()) {
+                add_diagnostic_event_locked(
+                    "malformed_notification",
+                    "Received NETCONF EOM marker without notification payload; dropped empty frame",
+                    frame_bytes,
+                    false
+                );
+                return;
+            }
+
+            const bool malformed = !is_valid_notification_document(frame_without_eom);
+            if (malformed) {
+                add_diagnostic_event_locked(
+                    "malformed_notification",
+                    "Received EOM-delimited data that is not a valid NETCONF notification; queued malformed frame",
+                    frame_bytes,
+                    false
+                );
+            }
+
+            enqueue_or_drop_locked(
+                frame_without_eom + NETCONF_NOTIFICATION_EOM,
+                malformed ? frame_bytes : 0
+            );
+        };
+
+        auto process_recovered_missing_eom_locked = [&](const std::string& frame_without_eom) {
+            const std::int64_t frame_bytes =
+                static_cast<std::int64_t>(frame_without_eom.size());
+
+            add_diagnostic_event_locked(
+                "malformed_notification",
+                "Recovered complete notification XML without NETCONF EOM before the next notification; queued recovered frame",
+                frame_bytes,
+                false
+            );
+
+            enqueue_or_drop_locked(frame_without_eom, frame_bytes);
+        };
+
+        auto process_rx_buffer_locked = [&]() {
+            bool progressed = true;
+
+            while (progressed) {
+                progressed = false;
+
+                if (_notif_rx_buffer.empty()) {
+                    _notif_rx_partial_timer_active = false;
+                    break;
                 }
+
+                const std::size_t first_notification =
+                    find_notification_start_tag(_notif_rx_buffer, 0);
+
+                if (first_notification != std::string::npos && first_notification > 0) {
+                    const std::string prefix = _notif_rx_buffer.substr(0, first_notification);
+                    if (!benign_notification_prefix(prefix)) {
+                        add_diagnostic_event_locked(
+                            "malformed_notification",
+                            "Received orphan notification bytes before a notification start tag; dropped orphan fragment",
+                            static_cast<std::int64_t>(prefix.size()),
+                            false
+                        );
+                        _notif_rx_buffer.erase(0, first_notification);
+                        _notif_rx_partial_timer_active = false;
+                        progressed = true;
+                        continue;
+                    }
+                }
+
+                std::size_t eom_pos = std::string::npos;
+                while (
+                    (
+                        eom_pos = _notif_rx_buffer.find(NETCONF_NOTIFICATION_EOM)
+                    ) != std::string::npos
+                ) {
+                    std::string frame = _notif_rx_buffer.substr(0, eom_pos);
+                    _notif_rx_buffer.erase(0, eom_pos + NETCONF_NOTIFICATION_EOM_LEN);
+                    _notif_rx_partial_timer_active = false;
+
+                    process_eom_frame_locked(frame);
+                    progressed = true;
+                }
+                if (_notif_rx_buffer.empty()) {
+                    _notif_rx_partial_timer_active = false;
+                    break;
+                }
+
+                std::size_t notification_start = find_notification_start_tag(_notif_rx_buffer, 0);
+                if (notification_start != std::string::npos) {
+                    std::size_t notification_end = std::string::npos;
+
+                    if (notification_end_after_start(
+                            _notif_rx_buffer,
+                            notification_start,
+                            notification_end
+                        )) {
+                        const std::size_t next_notification =
+                            find_notification_start_tag(_notif_rx_buffer, notification_end);
+
+                        if (next_notification != std::string::npos) {
+                            std::string recovered = _notif_rx_buffer.substr(0, notification_end);
+                            _notif_rx_buffer.erase(0, notification_end);
+                            _notif_rx_partial_timer_active = false;
+
+                            process_recovered_missing_eom_locked(recovered);
+                            progressed = true;
+                            continue;
+                        }
+                    } else {
+                        const std::size_t next_notification =
+                            find_notification_start_tag(_notif_rx_buffer, notification_start + 1);
+
+                        if (next_notification != std::string::npos) {
+                            std::string abandoned_partial =
+                                _notif_rx_buffer.substr(0, next_notification);
+
+                            _notif_rx_buffer.erase(0, next_notification);
+                            _notif_rx_partial_timer_active = false;
+
+                            const std::int64_t partial_bytes =
+                                static_cast<std::int64_t>(abandoned_partial.size());
+
+                            add_diagnostic_event_locked(
+                                "incomplete_notification",
+                                "Received a new notification start before the previous notification was completed; queued abandoned partial notification",
+                                partial_bytes,
+                                true
+                            );
+
+                            enqueue_or_drop_locked(std::move(abandoned_partial), partial_bytes);
+
+                            progressed = true;
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            if (_notif_rx_buffer.empty()) {
+                _notif_rx_partial_timer_active = false;
+            } else if (!_notif_rx_partial_timer_active) {
+                _notif_rx_partial_timer_active = true;
+                _notif_rx_partial_started_at = std::chrono::steady_clock::now();
+            }
+        };
+
+        auto partial_size_limit_reached_locked = [&]() -> bool {
+            if (notif_incomplete_max_kb_ <= 0 || _notif_rx_buffer.empty()) {
+                return false;
+            }
+
+            const std::size_t max_bytes =
+                static_cast<std::size_t>(notif_incomplete_max_kb_) * 1024;
+            return _notif_rx_buffer.size() >= max_bytes;
+        };
+
+        auto partial_timeout_reached_locked = [&]() -> bool {
+            if (notif_incomplete_timeout_ <= 0 ||
+                !_notif_rx_partial_timer_active ||
+                _notif_rx_buffer.empty()) {
+                return false;
+            }
+
+            const auto now = std::chrono::steady_clock::now();
+            return now - _notif_rx_partial_started_at >=
+                std::chrono::seconds(notif_incomplete_timeout_);
+        };
+
+        auto finalize_incomplete_locked = [&](const std::string& reason) {
+            if (_notif_rx_buffer.empty()) {
+                _notif_rx_partial_timer_active = false;
+                return;
+            }
+
+            std::string partial = std::move(_notif_rx_buffer);
+            _notif_rx_buffer.clear();
+            _notif_rx_partial_timer_active = false;
+
+            const std::int64_t partial_bytes =
+                static_cast<std::int64_t>(partial.size());
+
+            add_diagnostic_event_locked(
+                "incomplete_notification",
+                reason,
+                partial_bytes,
+                true
+            );
+
+            enqueue_or_drop_locked(std::move(partial), partial_bytes);
+        };
+
+        auto read_currently_available = [&]() -> std::string {
+            std::lock_guard<std::mutex> guard(notif_mutex_);
+
+            if (!notif_channel_ || !notif_session_) {
+                throw NetconfException("Notification channel/session is not active");
+            }
+
+            if (notif_socket_.get() != fd) {
+                throw NetconfException("Notification FD does not match active subscription socket");
+            }
+
+            return read_available_notification_bytes(
+                notif_channel_.get(),
+                notif_session_.get()
+            );
+        };
+
+        std::string bytes = read_currently_available();
+
+        {
+            std::lock_guard<std::mutex> lk(_notif_queue_mtx);
+
+            if (!bytes.empty()) {
+                _notif_rx_buffer.append(bytes);
+            }
+
+            process_rx_buffer_locked();
+
+            if (partial_size_limit_reached_locked()) {
+                finalize_incomplete_locked(
+                    "Received notification bytes without NETCONF EOM; size guard fired and queued partial notification"
+                );
             }
         }
 
-        for (auto& event : events_to_emit) {
-            NotificationEventBus::instance().emit(std::move(event));
-        }
+        flush_events_and_notifications();
 
-        if (queued_notification) {
-            _notif_queue_cv.notify_one();
+        while (true) {
+            bool should_wait = false;
+            int wait_ms = 0;
+
+            {
+                std::lock_guard<std::mutex> lk(_notif_queue_mtx);
+
+                process_rx_buffer_locked();
+
+                if (partial_size_limit_reached_locked()) {
+                    finalize_incomplete_locked(
+                        "Received notification bytes without NETCONF EOM; size guard fired and queued partial notification"
+                    );
+                } else if (partial_timeout_reached_locked()) {
+                    finalize_incomplete_locked(
+                        "Received notification bytes without NETCONF EOM; timeout guard fired and queued partial notification"
+                    );
+                }
+
+                if (!_notif_rx_buffer.empty() && notif_incomplete_timeout_ > 0) {
+                    const auto now = std::chrono::steady_clock::now();
+                    const auto deadline =
+                        _notif_rx_partial_started_at +
+                        std::chrono::seconds(notif_incomplete_timeout_);
+
+                    if (now >= deadline) {
+                        finalize_incomplete_locked(
+                            "Received notification bytes without NETCONF EOM; timeout guard fired and queued partial notification"
+                        );
+                    } else {
+                        const auto remaining_ms =
+                            std::chrono::duration_cast<std::chrono::milliseconds>(
+                                deadline - now
+                            ).count();
+
+                        wait_ms = static_cast<int>(
+                            std::min<long long>(
+                                std::max<long long>(1, remaining_ms),
+                                NOTIFICATION_POLL_SLICE_MS
+                            )
+                        );
+                        should_wait = true;
+                    }
+                }
+            }
+
+            flush_events_and_notifications();
+
+            if (!should_wait) {
+                break;
+            }
+
+            const int ready = poll_notification_fd(fd, wait_ms);
+            if (ready == 0) {
+                {
+                    std::lock_guard<std::mutex> lk(_notif_queue_mtx);
+                    if (partial_timeout_reached_locked()) {
+                        finalize_incomplete_locked(
+                            "Received notification bytes without NETCONF EOM; timeout guard fired and queued partial notification"
+                        );
+                    }
+                }
+                flush_events_and_notifications();
+                continue;
+            }
+
+            std::string more = read_currently_available();
+
+            {
+                std::lock_guard<std::mutex> lk(_notif_queue_mtx);
+                if (!more.empty()) {
+                    _notif_rx_buffer.append(more);
+                }
+
+                process_rx_buffer_locked();
+
+                if (partial_size_limit_reached_locked()) {
+                    finalize_incomplete_locked(
+                        "Received notification bytes without NETCONF EOM; size guard fired and queued partial notification"
+                    );
+                }
+            }
+
+            flush_events_and_notifications();
         }
 
     } catch (const std::exception& e) {
@@ -953,6 +1485,12 @@ std::string NetconfClient::subscribe_non_blocking(
             rpc,
             read_timeout_
         );
+
+        {
+            std::lock_guard<std::mutex> lk(_notif_queue_mtx);
+            _notif_rx_buffer.clear();
+            _notif_rx_partial_timer_active = false;
+        }
 
         // Now it is safe for the reactor to read real <notification> messages.
         NotificationReactorManager::instance().add(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,8 +28,17 @@ def pyNetX_module():
 
 
 @pytest.fixture(autouse=True)
-def clear_global_notification_events(pyNetX_module):
-    """Keep the process-wide health event bus isolated between tests."""
+def clear_global_notification_events(request):
+    """Keep the process-wide health event bus isolated between tests.
+
+    Static source-contract tests do not need the compiled pyNetX extension, so
+    avoid importing it unless the test actually requested ``pyNetX_module``.
+    """
+    if "pyNetX_module" not in request.fixturenames:
+        yield
+        return
+
+    pyNetX_module = request.getfixturevalue("pyNetX_module")
     pyNetX_module.clear_notification_events()
     yield
     pyNetX_module.clear_notification_events()

--- a/test/fake_netconf_ssh_server.py
+++ b/test/fake_netconf_ssh_server.py
@@ -89,6 +89,7 @@ class FakeNetconfSSHServer:
         password: str = "admin",
         rpc_responder: Callable[[str], str] | None = None,
         notifications: Iterable[str] | None = None,
+        notification_raw_chunks: Iterable[str] | None = None,
         incomplete_notification: str | None = None,
         notification_start_delay: float = 0.20,
         notification_interval: float = 0.05,
@@ -99,6 +100,7 @@ class FakeNetconfSSHServer:
         self.password = password
         self.rpc_responder = rpc_responder or (lambda rpc: OK_REPLY)
         self.notifications = list(notifications or [])
+        self.notification_raw_chunks = list(notification_raw_chunks or [])
         self.incomplete_notification = incomplete_notification
         self.notification_start_delay = notification_start_delay
         self.notification_interval = notification_interval
@@ -255,6 +257,20 @@ class FakeNetconfSSHServer:
 
     def _send_notifications(self, channel) -> None:
         time.sleep(self.notification_start_delay)
+
+        # Raw chunks are sent exactly as provided. These are used by stream-parser
+        # tests to simulate bad devices and TCP/SSH coalescing/splitting cases:
+        # multiple EOM-delimited notifications in one read, trailing partial
+        # frames, missing EOM between notifications, empty EOM frames, etc.
+        for chunk in self.notification_raw_chunks:
+            if self._stop.is_set():
+                return
+            try:
+                self._send_all(channel, chunk)
+            except Exception:
+                return
+            time.sleep(self.notification_interval)
+
         for payload in self.notifications:
             if self._stop.is_set():
                 return

--- a/test/test_notification_queue_deep_integration.py
+++ b/test/test_notification_queue_deep_integration.py
@@ -5,7 +5,7 @@ import asyncio
 import pytest
 
 from conftest import assert_recent_utc_timestamp
-from fake_netconf_ssh_server import FakeNetconfSSHServer, notification_xml
+from fake_netconf_ssh_server import NETCONF_EOM, FakeNetconfSSHServer, notification_xml
 from test_integration_fake_netconf_server import make_integration_client
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
@@ -158,5 +158,225 @@ async def test_incomplete_notification_size_limit_generates_health_event(pyNetX_
 
         queued = await client.next_notification_async(timeout_ms=1000)
         assert queued.startswith("<notification>")
+
+        client.delete_subscription()
+
+
+async def wait_for_health_event(pyNetX_module, expected_types: set[str], *, predicate=None, timeout: float = 5.0):
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        event = await pyNetX_module.next_notification_event_async(timeout_ms=500)
+        if event.valid and event.type in expected_types and (predicate is None or predicate(event)):
+            return event
+    raise AssertionError(f"did not receive health event with type in {expected_types!r}")
+
+
+@pytest.mark.asyncio
+async def test_coalesced_eom_delimited_notifications_are_split_into_fifo_entries(pyNetX_module):
+    notifications = [notification_xml(i) for i in range(1, 4)]
+    combined_chunk = "".join(notification + NETCONF_EOM for notification in notifications)
+
+    with FakeNetconfSSHServer(
+        notification_raw_chunks=[combined_chunk],
+        notification_start_delay=0.10,
+        notification_interval=0.0,
+    ) as server:
+        client = make_integration_client(pyNetX_module, server, notif_queue_size=10)
+        assert "<ok/>" in await client.subscribe_async(stream="NETCONF")
+
+        received = [await client.next_notification_async(timeout_ms=3000) for _ in range(3)]
+
+        assert ["<sequence>1</sequence>" in item for item in received] == [True, False, False]
+        assert ["<sequence>2</sequence>" in item for item in received] == [False, True, False]
+        assert ["<sequence>3</sequence>" in item for item in received] == [False, False, True]
+        assert all(item.endswith(NETCONF_EOM) for item in received)
+        assert client.notification_queue_size() == 0
+
+        client.delete_subscription()
+
+
+@pytest.mark.asyncio
+async def test_complete_notification_plus_trailing_partial_is_buffered_until_eom_arrives(pyNetX_module):
+    first = notification_xml(1)
+    second = notification_xml(2)
+    split_at = second.index("<event>")
+
+    with FakeNetconfSSHServer(
+        notification_raw_chunks=[
+            first + NETCONF_EOM + second[:split_at],
+            second[split_at:] + NETCONF_EOM,
+        ],
+        notification_start_delay=0.10,
+        notification_interval=0.20,
+    ) as server:
+        client = make_integration_client(
+            pyNetX_module,
+            server,
+            notif_queue_size=10,
+            notif_incomplete_timeout=2,
+        )
+        assert "<ok/>" in await client.subscribe_async(stream="NETCONF")
+
+        received_first = await client.next_notification_async(timeout_ms=3000)
+        received_second = await client.next_notification_async(timeout_ms=3000)
+
+        assert "<sequence>1</sequence>" in received_first
+        assert "<sequence>2</sequence>" in received_second
+        assert received_first.endswith(NETCONF_EOM)
+        assert received_second.endswith(NETCONF_EOM)
+        assert client.notification_queue_size() == 0
+
+        client.delete_subscription()
+
+
+@pytest.mark.asyncio
+async def test_new_notification_start_before_previous_completion_queues_abandoned_partial(pyNetX_module):
+    first = notification_xml(1)
+    second = notification_xml(2)
+    third = notification_xml(3)
+
+    second_partial = second[: second.index("<event>")]
+    third_split_at = third.index("<event>")
+    third_partial = third[:third_split_at]
+    third_rest = third[third_split_at:]
+
+    with FakeNetconfSSHServer(
+        notification_raw_chunks=[
+            first + NETCONF_EOM + second_partial + third_partial,
+            third_rest + NETCONF_EOM,
+        ],
+        notification_start_delay=0.10,
+        notification_interval=0.25,
+    ) as server:
+        client = make_integration_client(
+            pyNetX_module,
+            server,
+            notif_queue_size=10,
+            notif_incomplete_timeout=2,
+            label="abandoned-partial-leaf",
+        )
+        assert "<ok/>" in await client.subscribe_async(stream="NETCONF")
+
+        event_task = asyncio.create_task(
+            wait_for_health_event(
+                pyNetX_module,
+                {"incomplete_notification"},
+                predicate=lambda event: "new notification start" in event.message,
+            )
+        )
+
+        received_first = await client.next_notification_async(timeout_ms=3000)
+        abandoned_second = await client.next_notification_async(timeout_ms=3000)
+        recovered_third = await client.next_notification_async(timeout_ms=3000)
+        event = await event_task
+
+        assert "<sequence>1</sequence>" in received_first
+        assert received_first.endswith(NETCONF_EOM)
+
+        assert "<sequence>2</sequence>" in abandoned_second
+        assert "<sequence>3</sequence>" not in abandoned_second
+        assert not abandoned_second.endswith(NETCONF_EOM)
+
+        assert "<sequence>3</sequence>" in recovered_third
+        assert recovered_third.endswith(NETCONF_EOM)
+
+        assert event.label == "abandoned-partial-leaf"
+        assert event.partial_bytes == len(second_partial)
+        assert event.incomplete_notifications_received >= 1
+        assert_recent_utc_timestamp(event.timestamp)
+
+        client.delete_subscription()
+
+
+@pytest.mark.asyncio
+async def test_malformed_eom_delimited_frame_is_queued_and_reported(pyNetX_module):
+    malformed = "<notification><eventTime>bad</notification>"
+
+    with FakeNetconfSSHServer(
+        notification_raw_chunks=[malformed + NETCONF_EOM],
+        notification_start_delay=0.10,
+        notification_interval=0.0,
+    ) as server:
+        client = make_integration_client(
+            pyNetX_module,
+            server,
+            notif_queue_size=10,
+            label="malformed-frame-leaf",
+        )
+        assert "<ok/>" in await client.subscribe_async(stream="NETCONF")
+
+        received = await client.next_notification_async(timeout_ms=3000)
+        event = await wait_for_health_event(
+            pyNetX_module,
+            {"malformed_notification"},
+            predicate=lambda candidate: "EOM-delimited data" in candidate.message,
+        )
+
+        assert received == malformed + NETCONF_EOM
+        assert event.label == "malformed-frame-leaf"
+        assert event.partial_bytes == len(malformed)
+        assert_recent_utc_timestamp(event.timestamp)
+
+        client.delete_subscription()
+
+
+@pytest.mark.asyncio
+async def test_orphan_bytes_before_notification_are_dropped_and_reported(pyNetX_module):
+    orphan = "bad-device-prefix"
+    notification = notification_xml(1)
+
+    with FakeNetconfSSHServer(
+        notification_raw_chunks=[orphan + notification + NETCONF_EOM],
+        notification_start_delay=0.10,
+        notification_interval=0.0,
+    ) as server:
+        client = make_integration_client(
+            pyNetX_module,
+            server,
+            notif_queue_size=10,
+            label="orphan-prefix-leaf",
+        )
+        assert "<ok/>" in await client.subscribe_async(stream="NETCONF")
+
+        received = await client.next_notification_async(timeout_ms=3000)
+        event = await wait_for_health_event(
+            pyNetX_module,
+            {"malformed_notification"},
+            predicate=lambda candidate: "orphan notification bytes" in candidate.message,
+        )
+
+        assert orphan not in received
+        assert "<sequence>1</sequence>" in received
+        assert received.endswith(NETCONF_EOM)
+        assert event.label == "orphan-prefix-leaf"
+        assert event.partial_bytes == len(orphan)
+
+        client.delete_subscription()
+
+
+@pytest.mark.asyncio
+async def test_empty_eom_frame_is_reported_and_dropped(pyNetX_module):
+    with FakeNetconfSSHServer(
+        notification_raw_chunks=[NETCONF_EOM],
+        notification_start_delay=0.10,
+        notification_interval=0.0,
+    ) as server:
+        client = make_integration_client(
+            pyNetX_module,
+            server,
+            notif_queue_size=10,
+            label="empty-eom-leaf",
+        )
+        assert "<ok/>" in await client.subscribe_async(stream="NETCONF")
+
+        event = await wait_for_health_event(
+            pyNetX_module,
+            {"malformed_notification"},
+            predicate=lambda candidate: "EOM marker without notification payload" in candidate.message,
+        )
+
+        assert event.label == "empty-eom-leaf"
+        assert client.notification_queue_size() == 0
+        assert client.peek_notifications(-1) == []
 
         client.delete_subscription()

--- a/test/test_static_source_contracts.py
+++ b/test/test_static_source_contracts.py
@@ -88,3 +88,37 @@ def test_type_stub_lists_only_current_health_event_schema(project_root):
     ]
     for line in expected_lines:
         assert line in stub
+
+
+def test_notification_stream_parser_source_contract_includes_today_fix(project_root):
+    root = require_source_root(project_root)
+    netconf_hpp = read(root, "include/netconf_client.hpp")
+    non_blocking_cpp = read(root, "src/netconf_client_non_blocking.cpp")
+    blocking_cpp = read(root, "src/netconf_client_blocking.cpp")
+
+    assert "std::string _notif_rx_buffer" in netconf_hpp
+    assert "_notif_rx_partial_timer_active" in netconf_hpp
+    assert "_notif_rx_partial_started_at" in netconf_hpp
+
+    assert 'NETCONF_NOTIFICATION_EOM = "]]>]]>"' in non_blocking_cpp
+    assert "read_available_notification_bytes" in non_blocking_cpp
+    assert "process_rx_buffer_locked" in non_blocking_cpp
+    assert "process_eom_frame_locked" in non_blocking_cpp
+    assert "process_recovered_missing_eom_locked" in non_blocking_cpp
+    assert "find_notification_start_tag(_notif_rx_buffer, notification_start + 1)" in non_blocking_cpp
+    assert "Received a new notification start before the previous notification was completed" in non_blocking_cpp
+    assert '"malformed_notification"' in non_blocking_cpp
+    assert '"incomplete_notification"' in non_blocking_cpp
+    assert "_notif_rx_buffer.clear();" in blocking_cpp
+
+
+def test_notification_stream_parser_drops_orphan_prefix_before_eom_frames(project_root):
+    root = require_source_root(project_root)
+    non_blocking_cpp = read(root, "src/netconf_client_non_blocking.cpp")
+
+    orphan_message = "Received orphan notification bytes before a notification start tag; dropped orphan fragment"
+    eom_loop = "eom_pos = _notif_rx_buffer.find(NETCONF_NOTIFICATION_EOM)"
+
+    assert orphan_message in non_blocking_cpp
+    assert eom_loop in non_blocking_cpp
+    assert non_blocking_cpp.index(orphan_message) < non_blocking_cpp.index(eom_loop)


### PR DESCRIPTION
- Introduced a persistent notification receive buffer to handle multiple complete notifications, partial notifications, and malformed data.
- Improved parsing logic to split multiple EOM-delimited notifications received in a single read.
- Added handling for abandoned partial notifications when a new notification starts before the previous one completes.
- Implemented health events for malformed notifications and incomplete notifications.
- Updated documentation to reflect changes in notification behavior and parser diagnostics.
- Enhanced tests to cover new notification stream scenarios, including coalesced notifications and malformed frames.